### PR TITLE
Fix Alternative instance

### DIFF
--- a/Data/String/Parse.hs
+++ b/Data/String/Parse.hs
@@ -68,7 +68,7 @@ instance MonadPlus Parser where
     mzero = fail "Parser.MonadPlus.mzero"
     mplus f g = Parser $ \buf err ok ->
         -- rewrite the err callback of @f to call @g
-        runParser f buf (\buf' _ -> runParser g buf' err ok) ok
+        runParser f buf (\_ _ -> runParser g buf err ok) ok
 instance Functor Parser where
     fmap f p = Parser $ \buf err ok ->
         runParser p buf err (\b a -> ok b (f a))


### PR DESCRIPTION
In the case of an alternative, I think we want to try again but from the the last good known state of the Parser so use the original buffer instead of the one given by the error function.
